### PR TITLE
Fix sidebar width sync

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,10 @@ import './styles/App.css';
 
 function App() {
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
-  const [sidebarWidth] = useState(window.innerWidth * 0.2);
+  const [sidebarWidth, setSidebarWidth] = useState<number>(() => {
+    if (typeof window === 'undefined') return 350;
+    return parseInt(localStorage.getItem('sidebarWidth') ?? '350');
+  });
 
   useEffect(() => {
     const handleResize = () => {
@@ -23,6 +26,8 @@ function App() {
         <Sidebar
           isCollapsed={isSidebarCollapsed}
           setIsCollapsed={setIsSidebarCollapsed}
+          width={sidebarWidth}
+          setWidth={setSidebarWidth}
         />
         <main
           style={{ 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,13 +6,14 @@ import { motion, AnimatePresence } from 'framer-motion';
 interface SidebarProps {
   isCollapsed: boolean;
   setIsCollapsed: React.Dispatch<React.SetStateAction<boolean>>;
+  width: number;
+  setWidth: React.Dispatch<React.SetStateAction<number>>;
 }
 
 const [minWidth, maxWidth] = [200, 500];
 
-const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, setIsCollapsed }) => {
+const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, setIsCollapsed, width, setWidth }) => {
   const { materials, selectMaterial, deleteMaterial } = useMaterials();
-  const [width, setWidth] = useState(parseInt(localStorage.getItem("sidebarWidth") ?? '350'));
   const [isDragging, setIsDragging] = useState(false);
   const sidebarRef = useRef<HTMLDivElement>(null);
   const isDragged = useRef(false);


### PR DESCRIPTION
## Summary
- track sidebar width in `App` and pass it into `Sidebar`
- update sidebar logic to use the width passed from props

## Testing
- `CI=true npm test --silent` *(fails: Error creating WebGL context)*

------
https://chatgpt.com/codex/tasks/task_e_684127a447f0832b960e5ca1c9c19b73