### PR TITLE
fix: log web vitals only once

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,6 @@ root.render(
   </React.StrictMode>
 );
 
-reportWebVitals(console.log);
 // Or for more advanced analytics integration
 reportWebVitals((metrics) => {
   console.log(metrics);


### PR DESCRIPTION
## Summary
- remove duplicate web vitals logging

## Testing
- `npm test -- --watchAll=false` *(fails: Error creating WebGL context)*

------
https://chatgpt.com/codex/tasks/task_e_68412c73875c832bbef78fa0add26434