### PR TITLE
Fix App test

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+
+// Mock components that rely on WebGL to avoid JSDOM errors
+jest.mock('./components/MaterialPreview', () => () => <div />);
+jest.mock('./components/MaterialEditor', () => () => <div />);
+
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders sidebar title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const titleElement = screen.getByText(/materials/i);
+  expect(titleElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- test for sidebar heading text instead of CRA boilerplate
- stub components that use WebGL for Jest

## Testing
- `npm test --silent -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_68412c757e7c832ba433600459d876a7