### PR TITLE
Add GitHub Pages homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "material-explorer",
   "version": "0.1.0",
+  "homepage": "https://mikechaves.github.io/material-explorer",
   "private": true,
   "dependencies": {
     "@craco/craco": "^5.9.0",


### PR DESCRIPTION
## Summary
- set the `homepage` field so CRA builds for GitHub Pages

## Testing
- `npm run build`
- `npx -y gh-pages -d build` *(fails: Error: Failed to get remote.origin.url)*

------
https://chatgpt.com/codex/tasks/task_e_68413bfa5f28832ba7752f39cfc1ac3e