### PR TITLE
[codex] add texture storage guardrails

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,7 +94,7 @@ function App() {
                       ? 'calc(100% - 64px)'
                       : `calc(100% - ${sidebarWidth}px)`,
                 }}
-                className="h-full transition-all duration-300 ease-in-out overflow-hidden"
+                className="h-full box-border pt-14 md:pt-0 transition-all duration-300 ease-in-out overflow-hidden"
               >
                 <Suspense fallback={<div className="h-full w-full bg-black" />}>
                   <MaterialEditor />

--- a/src/components/MaterialEditor.tsx
+++ b/src/components/MaterialEditor.tsx
@@ -41,6 +41,11 @@ import {
 import { validateTextureDataUrl, validateTextureUploadFile } from './editor/textureUpload';
 import { getLocalStorageItem, removeLocalStorageItem, setLocalStorageItem } from '../utils/localStorage';
 import { emitTelemetryEvent } from '../utils/telemetry';
+import {
+  analyzeMaterialLibraryStorage,
+  formatEncodedSize,
+  summarizeMaterialTextures,
+} from '../utils/materialStorageBudget';
 
 const HISTORY_LIMIT = 120;
 const DRAFT_AUTOSAVE_KEY = 'materialEditorDraftAutosaveV1';
@@ -535,10 +540,53 @@ const MaterialEditor: React.FC = () => {
       updatedAt: now,
       ...(material.id ? {} : { createdAt: now }),
     });
+    const existingIndex = materials.findIndex((entry) => entry.id === full.id);
+    const projectedMaterials =
+      existingIndex >= 0 ? materials.map((entry) => (entry.id === full.id ? full : entry)) : [...materials, full];
+    const storageReport = analyzeMaterialLibraryStorage(projectedMaterials);
 
-    if (material.id) updateMaterial(full);
+    if (storageReport.level === 'block') {
+      notify({
+        variant: 'warn',
+        title: 'Storage limit warning',
+        message: `This library would use about ${formatEncodedSize(
+          storageReport.serializedChars
+        )} locally. Remove texture maps or export JSON before saving more embedded textures.`,
+      });
+      emitTelemetryEvent(
+        'materials.save.projected_storage_blocked',
+        {
+          materialCount: projectedMaterials.length,
+          serializedChars: storageReport.serializedChars,
+          textureChars: storageReport.textureChars,
+        },
+        'warn'
+      );
+      return;
+    }
+
+    if (storageReport.level === 'warn') {
+      notify({
+        variant: 'warn',
+        title: 'Storage getting full',
+        message: `This library is about ${formatEncodedSize(
+          storageReport.serializedChars
+        )} locally. Export JSON backups or clear unused textures soon.`,
+      });
+      emitTelemetryEvent(
+        'materials.save.projected_storage_warned',
+        {
+          materialCount: projectedMaterials.length,
+          serializedChars: storageReport.serializedChars,
+          textureChars: storageReport.textureChars,
+        },
+        'warn'
+      );
+    }
+
+    if (existingIndex >= 0) updateMaterial(full);
     else addMaterial(full);
-  }, [addMaterial, material, updateMaterial]);
+  }, [addMaterial, material, materials, notify, updateMaterial]);
 
   const duplicateCurrentMaterial = React.useCallback(() => {
     const now = Date.now();
@@ -700,6 +748,7 @@ const MaterialEditor: React.FC = () => {
   const canRedo = redoStack.length > 0;
   const surfaceDirty = React.useMemo(() => isSurfaceSectionDirty(material, baselineDraft), [baselineDraft, material]);
   const opticsDirty = React.useMemo(() => isOpticsSectionDirty(material, baselineDraft), [baselineDraft, material]);
+  const textureStorageSummary = React.useMemo(() => summarizeMaterialTextures(material), [material]);
 
   const resetDraftChanges = React.useCallback(() => {
     setMaterial(cloneDraft(baselineDraft));
@@ -877,6 +926,7 @@ const MaterialEditor: React.FC = () => {
               onChange={handleChange}
               onUploadMap={uploadMap}
               setMaterial={setMaterialWithHistory}
+              textureStorageSummary={textureStorageSummary}
             />
 
             <DraftHistoryCard

--- a/src/components/editor/TextureControls.tsx
+++ b/src/components/editor/TextureControls.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
 import type { MaterialDraft } from '../../types/material';
 import { Control } from './EditorFields';
+import type { TextureStorageSummary } from '../../utils/materialStorageBudget';
+import { formatEncodedSize } from '../../utils/materialStorageBudget';
 
 type TextureControlsProps = {
   material: MaterialDraft;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onUploadMap: (key: keyof MaterialDraft, file: File) => Promise<void>;
   setMaterial: React.Dispatch<React.SetStateAction<MaterialDraft>>;
+  textureStorageSummary: TextureStorageSummary;
 };
 
 function uploadFromInput(
@@ -33,7 +36,20 @@ function UploadButton({ onChange }: { onChange: (event: React.ChangeEvent<HTMLIn
 const rowClass = 'section-shell px-3 py-3 flex items-start justify-between gap-3';
 const actionClass = 'ui-btn px-3 py-1.5 text-xs font-semibold';
 
-export function TextureControls({ material, onChange, onUploadMap, setMaterial }: TextureControlsProps) {
+export function TextureControls({
+  material,
+  onChange,
+  onUploadMap,
+  setMaterial,
+  textureStorageSummary,
+}: TextureControlsProps) {
+  const textureSummaryText =
+    textureStorageSummary.textureCount === 0
+      ? 'No embedded textures in this draft.'
+      : `${formatEncodedSize(textureStorageSummary.textureChars)} embedded across ${
+          textureStorageSummary.textureCount
+        } ${textureStorageSummary.textureCount === 1 ? 'map' : 'maps'}.`;
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
@@ -42,6 +58,9 @@ export function TextureControls({ material, onChange, onUploadMap, setMaterial }
           <div className="text-xs ui-muted">Maps, tiling, and advanced material detail.</div>
           <div className="mt-1 text-[11px] text-slate-300/75">
             Upload images only. Recommended max size: 4 MB per map.
+          </div>
+          <div className="mt-1 text-[11px] text-slate-300/75" data-testid="texture-storage-summary">
+            Draft storage: {textureSummaryText} Embedded textures count against browser storage.
           </div>
         </div>
       </div>

--- a/src/components/editor/textureUpload.ts
+++ b/src/components/editor/textureUpload.ts
@@ -1,5 +1,6 @@
+import { MAX_TEXTURE_DATA_URL_CHARS } from '../../utils/materialStorageBudget';
+
 const MAX_TEXTURE_FILE_BYTES = 4 * 1024 * 1024; // 4 MB
-const MAX_TEXTURE_DATA_URL_CHARS = 2_500_000;
 
 export function validateTextureUploadFile(file: File): string | null {
   const type = file.type?.trim();

--- a/src/components/sidebar/importMaterials.test.ts
+++ b/src/components/sidebar/importMaterials.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { parseImportedMaterials, validateImportFileSize } from './importMaterials';
 import type { Material } from '../../types/material';
+import { LOCAL_LIBRARY_STORAGE_BLOCK_CHARS } from '../../utils/materialStorageBudget';
 
 function makeMaterial(id: string, name: string): Material {
   const now = Date.now();
@@ -70,6 +71,24 @@ describe('importMaterials', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.message).toContain('very large embedded texture');
+  });
+
+  it('rejects imports that would exceed the local library storage budget', () => {
+    const existing = [
+      {
+        ...makeMaterial('m-existing-large', 'Existing Large'),
+        baseColorMap: `data:image/png;base64,${'a'.repeat(LOCAL_LIBRARY_STORAGE_BLOCK_CHARS)}`,
+      },
+    ];
+    const payload = {
+      version: 1,
+      materials: [makeMaterial('m-storage-budget', 'One More Material')],
+    };
+
+    const result = parseImportedMaterials(JSON.stringify(payload), existing);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toContain('local library');
   });
 
   it('validates file size limits', () => {

--- a/src/components/sidebar/importMaterials.ts
+++ b/src/components/sidebar/importMaterials.ts
@@ -1,13 +1,15 @@
 import type { Material } from '../../types/material';
 import { createMaterialFromDraft, normalizeMaterial } from '../../utils/material';
+import {
+  analyzeMaterialLibraryStorage,
+  formatEncodedSize,
+  MAX_TEXTURE_DATA_URL_CHARS,
+  TEXTURE_FIELDS,
+} from '../../utils/materialStorageBudget';
 
 const MAX_IMPORT_FILE_BYTES = 8 * 1024 * 1024; // 8 MB
 const MAX_IMPORT_JSON_CHARS = 12 * 1024 * 1024;
 const MAX_IMPORT_MATERIALS = 600;
-const MAX_TEXTURE_DATA_URL_CHARS = 2_500_000;
-const textureFields: Array<
-  'baseColorMap' | 'normalMap' | 'roughnessMap' | 'metalnessMap' | 'aoMap' | 'emissiveMap' | 'alphaMap'
-> = ['baseColorMap', 'normalMap', 'roughnessMap', 'metalnessMap', 'aoMap', 'emissiveMap', 'alphaMap'];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value);
@@ -62,7 +64,7 @@ export function parseImportedMaterials(
   }
 
   const oversizedTextureMaterial = normalized.find((material) =>
-    textureFields.some((field) => {
+    TEXTURE_FIELDS.some((field) => {
       const value = material[field];
       return typeof value === 'string' && value.length > MAX_TEXTURE_DATA_URL_CHARS;
     })
@@ -84,6 +86,16 @@ export function parseImportedMaterials(
     existingIds.add(created.id);
     return created;
   });
+
+  const storageReport = analyzeMaterialLibraryStorage([...existingMaterials, ...imported]);
+  if (storageReport.level === 'block') {
+    return {
+      ok: false,
+      message: `Import would make the local library about ${formatEncodedSize(
+        storageReport.serializedChars
+      )}. Split the file or remove embedded textures before importing.`,
+    };
+  }
 
   return { ok: true, materials: imported };
 }

--- a/src/utils/materialStorageBudget.test.ts
+++ b/src/utils/materialStorageBudget.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import type { Material } from '../types/material';
+import {
+  analyzeMaterialLibraryStorage,
+  formatEncodedSize,
+  LOCAL_LIBRARY_STORAGE_BLOCK_CHARS,
+  LOCAL_LIBRARY_STORAGE_WARN_CHARS,
+  summarizeMaterialTextures,
+} from './materialStorageBudget';
+
+function makeMaterial(overrides: Partial<Material> = {}): Material {
+  const now = Date.now();
+  return {
+    id: overrides.id ?? 'mat-1',
+    name: overrides.name ?? 'Material',
+    color: overrides.color ?? '#ffffff',
+    metalness: overrides.metalness ?? 0.5,
+    roughness: overrides.roughness ?? 0.5,
+    emissive: overrides.emissive ?? '#000000',
+    emissiveIntensity: overrides.emissiveIntensity ?? 0,
+    clearcoat: overrides.clearcoat ?? 0,
+    clearcoatRoughness: overrides.clearcoatRoughness ?? 0.03,
+    transmission: overrides.transmission ?? 0,
+    ior: overrides.ior ?? 1.5,
+    opacity: overrides.opacity ?? 1,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    ...overrides,
+  };
+}
+
+describe('materialStorageBudget', () => {
+  it('summarizes embedded texture payloads', () => {
+    const material = makeMaterial({
+      baseColorMap: 'data:image/png;base64,abc',
+      normalMap: 'data:image/png;base64,defghi',
+    });
+
+    expect(summarizeMaterialTextures(material)).toEqual({
+      textureCount: 2,
+      textureChars: material.baseColorMap!.length + material.normalMap!.length,
+    });
+  });
+
+  it('classifies projected library storage levels', () => {
+    const ok = analyzeMaterialLibraryStorage([makeMaterial({ baseColorMap: 'a'.repeat(1024) })]);
+    const warn = analyzeMaterialLibraryStorage([
+      makeMaterial({ baseColorMap: 'a'.repeat(LOCAL_LIBRARY_STORAGE_WARN_CHARS) }),
+    ]);
+    const block = analyzeMaterialLibraryStorage([
+      makeMaterial({ baseColorMap: 'a'.repeat(LOCAL_LIBRARY_STORAGE_BLOCK_CHARS) }),
+    ]);
+
+    expect(ok.level).toBe('ok');
+    expect(warn.level).toBe('warn');
+    expect(block.level).toBe('block');
+  });
+
+  it('formats encoded payload sizes for user feedback', () => {
+    expect(formatEncodedSize(0)).toBe('0 KB');
+    expect(formatEncodedSize(1024)).toBe('1 KB');
+    expect(formatEncodedSize(2 * 1024 * 1024)).toBe('2.0 MB');
+  });
+});

--- a/src/utils/materialStorageBudget.ts
+++ b/src/utils/materialStorageBudget.ts
@@ -1,0 +1,67 @@
+import type { Material, MaterialDraft } from '../types/material';
+
+export const TEXTURE_FIELDS = [
+  'baseColorMap',
+  'normalMap',
+  'roughnessMap',
+  'metalnessMap',
+  'aoMap',
+  'emissiveMap',
+  'alphaMap',
+] as const;
+
+export type TextureField = (typeof TEXTURE_FIELDS)[number];
+
+export const MAX_TEXTURE_DATA_URL_CHARS = 2_500_000;
+export const LOCAL_LIBRARY_STORAGE_WARN_CHARS = 3_250_000;
+export const LOCAL_LIBRARY_STORAGE_BLOCK_CHARS = 4_250_000;
+
+type MaterialLike = Material | MaterialDraft;
+
+export type TextureStorageSummary = {
+  textureCount: number;
+  textureChars: number;
+};
+
+export type MaterialLibraryStorageReport = {
+  serializedChars: number;
+  textureChars: number;
+  level: 'ok' | 'warn' | 'block';
+};
+
+export function summarizeMaterialTextures(material: MaterialLike): TextureStorageSummary {
+  return TEXTURE_FIELDS.reduce<TextureStorageSummary>(
+    (summary, field) => {
+      const value = material[field];
+      if (typeof value !== 'string' || value.length === 0) return summary;
+      return {
+        textureCount: summary.textureCount + 1,
+        textureChars: summary.textureChars + value.length,
+      };
+    },
+    { textureCount: 0, textureChars: 0 }
+  );
+}
+
+export function formatEncodedSize(chars: number): string {
+  if (chars <= 0) return '0 KB';
+  const kib = chars / 1024;
+  if (kib < 1024) return `${Math.max(1, Math.round(kib))} KB`;
+  return `${(kib / 1024).toFixed(1)} MB`;
+}
+
+export function analyzeMaterialLibraryStorage(materials: Material[]): MaterialLibraryStorageReport {
+  const serializedChars = JSON.stringify(materials).length;
+  const textureChars = materials.reduce(
+    (total, material) => total + summarizeMaterialTextures(material).textureChars,
+    0
+  );
+  const level =
+    serializedChars >= LOCAL_LIBRARY_STORAGE_BLOCK_CHARS
+      ? 'block'
+      : serializedChars >= LOCAL_LIBRARY_STORAGE_WARN_CHARS
+        ? 'warn'
+        : 'ok';
+
+  return { serializedChars, textureChars, level };
+}

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -370,6 +370,23 @@ test('rejects oversized texture uploads with clear feedback', async ({ page }) =
   await expect(page.getByText('Texture file is too large. Maximum supported size is 4 MB.')).toBeVisible();
 });
 
+test('shows embedded texture storage after upload', async ({ page }) => {
+  const onePixelPng = Buffer.from(
+    'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/axk6FoAAAAASUVORK5CYII=',
+    'base64'
+  );
+  const textureInput = page.locator('input[type="file"][accept="image/*"]').first();
+
+  await expect(page.getByTestId('texture-storage-summary')).toContainText('No embedded textures');
+  await textureInput.setInputFiles({
+    name: 'one-pixel.png',
+    mimeType: 'image/png',
+    buffer: onePixelPng,
+  });
+
+  await expect(page.getByTestId('texture-storage-summary')).toContainText('embedded across 1 map');
+});
+
 test('can export materials as JSON', async ({ page }) => {
   await page.goto('/');
   await page.evaluate(


### PR DESCRIPTION
## Summary

- Add shared material storage budget helpers for embedded texture payloads.
- Show the current draft texture storage footprint in the editor texture panel.
- Warn or block projected material saves before the local library becomes too large for browser storage.
- Block JSON imports that would push the local material library over the storage budget.
- Fix mobile spacing so the collapsed sidebar menu button does not overlap the first editor heading.

## Validation

- `npm run quality:full`
- Browser QA at `http://127.0.0.1:5173/` on desktop and mobile `390x844`
- Desktop and mobile console checks showed no warnings or errors

## Notes

This improves feedback and prevents over-budget local saves/imports. It does not yet compress or downscale texture images automatically.